### PR TITLE
Update detectdaterangedialog.cpp

### DIFF
--- a/src/detectdaterangedialog.cpp
+++ b/src/detectdaterangedialog.cpp
@@ -500,10 +500,10 @@ void DetectDateRangeDialog::showDateRange(DateRangeType type)
     switch (type) {
         case DateRangeType::RawData:
         {
-            auto dataStartStr = ecProject_->generalStartDate()
+            QString dataStartStr = ecProject_->generalStartDate()
                                 + QStringLiteral("T")
                                 + ecProject_->generalStartTime();
-            auto dataEndStr = ecProject_->generalEndDate()
+            QString dataEndStr = ecProject_->generalEndDate()
                               + QStringLiteral("T")
                               + ecProject_->generalEndTime();
             auto dataStart = QDateTime::fromString(dataStartStr, Qt::ISODate);
@@ -525,10 +525,10 @@ void DetectDateRangeDialog::showDateRange(DateRangeType type)
             if (ecProject_->screenRotMethod() == 3
                 || ecProject_->screenRotMethod() == 4)
             {
-                auto pfStartStr = ecProject_->planarFitStartDate()
+                QString pfStartStr = ecProject_->planarFitStartDate()
                                   + QStringLiteral("T")
                                   + ecProject_->planarFitStartTime();
-                auto pfEndStr = ecProject_->planarFitEndDate()
+                QString pfEndStr = ecProject_->planarFitEndDate()
                                 + QStringLiteral("T")
                                 + ecProject_->planarFitEndTime();
                 auto pfStart = QDateTime::fromString(pfStartStr, Qt::ISODate);
@@ -550,10 +550,10 @@ void DetectDateRangeDialog::showDateRange(DateRangeType type)
         {
             if (ecProject_->screenTlagMeth() == 4)
             {
-                auto tlStartStr = ecProject_->timelagOptStartDate()
+                QString tlStartStr = ecProject_->timelagOptStartDate()
                                   + QStringLiteral("T")
                                   + ecProject_->timelagOptStartTime();
-                auto tlEndStr = ecProject_->timelagOptEndDate()
+                QString tlEndStr = ecProject_->timelagOptEndDate()
                                 + QStringLiteral("T")
                                 + ecProject_->timelagOptEndTime();
                 auto tlStart = QDateTime::fromString(tlStartStr, Qt::ISODate);
@@ -575,10 +575,10 @@ void DetectDateRangeDialog::showDateRange(DateRangeType type)
         {
             if (isSpectraSubsetPosssible())
             {
-                auto spStartStr = ecProject_->spectraStartDate()
+                QString spStartStr = ecProject_->spectraStartDate()
                                   + QStringLiteral("T")
                                   + ecProject_->spectraStartTime();
-                auto spEndStr = ecProject_->spectraEndDate()
+                QString spEndStr = ecProject_->spectraEndDate()
                                 + QStringLiteral("T")
                                 + ecProject_->spectraEndTime();
                 auto spStart = QDateTime::fromString(spStartStr, Qt::ISODate);


### PR DESCRIPTION
Trying to compile with linux system : build-eddypro_win-Desktop_Qt_5_5_1_GCC_64bit-Debug
An error occured at line 509. I assumed "auto" variable types (defined at lines 503 and 506) were not correct and changed them to "QString"
I did the same for the other cases of function showDateRange lines 528, 531, 553, 556, 578, 581.

I then could make my first runs with EddyPro on linux !!!

Best
Florent
